### PR TITLE
[main@3fbec7c] Update AL-Go System Files from microsoft/AL-Go-PTE@preview - a394216

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,5 @@
 {
   "type": "PTE",
   "templateUrl": "https://github.com/microsoft/AL-Go-PTE@preview",
-  "templateSha": "e827ae84eaf295b7b71212b99d0d1a52b996f84a"
+  "templateSha": "a3942163655ac899bec6037747164b554e27ce69"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -14,6 +14,8 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 - Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
 - Issue 1268 Do not throw an un-understandable error during nuGet download
 - Performance test sample code in 25.4 contains objects with ID 149201 and 149202, which are not renumbered
+- Issue 798 Publish To Environment breaks CI/CD pipelines
+- Issue 1182 Runs-on setting type is ambiguous - string or array
 
 ### New Workflow specific settings
 
@@ -34,6 +36,14 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 
 > [!NOTE]
 > The projects mentioned here are AL-Go projects in a multi-project repository. A repository can contain multiple projects and a project can contain multiple apps.
+
+### Run "Update AL-Go System Files" on multiple branches
+
+_Update AL-Go System Files_ has a new input to specify a list of branches to be updated in a single workflow run.
+When running the workflow on a schedule, you can now also specify `includeBranches` in `workflowSchedule` setting, which allows you to update the specified branches. Read more at https://aka.ms/algosettings#workflowSchedule.
+
+> [!NOTE]
+> When running "Update AL-Go System Files" on multiple branches, the template repository URL will be determined based on the branch the workflow runs on and it will be used for all of the specified branches.
 
 ### Support for incremental builds
 

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -50,18 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,7 +69,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go/Actions/AddExistingApp@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/AddExistingApp@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -48,7 +48,7 @@ jobs:
       powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -59,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -73,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,16 +149,25 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: templateUrl
 
+      - name: Read secrets
+        id: ReadSecrets
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: 'ghTokenWorkflow'
+
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           downloadLatest: true
 
   Build:
@@ -203,12 +212,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -217,7 +226,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -249,12 +258,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -268,7 +277,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -276,7 +285,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Deploy@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -288,7 +297,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -311,25 +320,25 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Deliver@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -349,7 +358,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -60,19 +60,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -80,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go/Actions/CreateApp@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CreateApp@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -50,7 +50,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -59,19 +59,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -90,7 +90,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -112,13 +112,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -137,7 +137,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go/Actions/CreateDevelopmentEnvironment@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CreateDevelopmentEnvironment@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -66,18 +66,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -85,7 +85,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go/Actions/CreateApp@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CreateApp@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -78,7 +78,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -87,20 +87,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: templateUrl,repoName,type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -109,15 +109,16 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
+          token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).TokenForPush }}
           downloadLatest: true
 
       - name: Analyze Artifacts
@@ -208,7 +209,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go/Actions/CreateReleaseNotes@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CreateReleaseNotes@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           tag_name: ${{ github.event.inputs.tag }}
@@ -250,13 +251,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -294,7 +295,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go/Actions/Deliver@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Deliver@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -307,7 +308,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go/Actions/Deliver@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Deliver@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -351,13 +352,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -365,7 +366,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -383,7 +384,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -62,18 +62,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -81,7 +81,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go/Actions/CreateApp@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CreateApp@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -30,7 +30,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -41,13 +41,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -55,7 +55,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -45,7 +45,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -54,18 +54,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +73,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -30,7 +30,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -41,13 +41,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -55,7 +55,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -30,7 +30,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -41,13 +41,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -55,7 +55,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -36,7 +36,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -45,19 +45,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
@@ -107,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/98de5bf31c06a3bff621c640bdfbe7853f9f54c9/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/41a2375645046812eb93fd5a67b5e0dd4a4438a1/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -141,21 +141,21 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Get Artifacts for deployment
-        uses: microsoft/AL-Go/Actions/GetArtifactsForDeployment@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/GetArtifactsForDeployment@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Deploy@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -175,7 +175,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -194,7 +194,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@41a2375645046812eb93fd5a67b5e0dd4a4438a1
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
@@ -57,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           get: shortLivedArtifactsRetentionDays
@@ -76,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -122,7 +122,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Troubleshooting@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -15,6 +15,10 @@ on:
         description: Direct Commit?
         type: boolean
         default: false
+      includeBranches:
+        description: Specify a comma-separated list of branches to update. Wildcards are supported. The AL-Go settings will be read for every branch. Leave empty to update the current branch only.
+        required: false
+        default: ''
 
 permissions:
   actions: read
@@ -30,81 +34,117 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
+  Initialize:
+    runs-on: windows-latest
+    name: Initialize
+    outputs:
+      UpdateBranches: ${{ steps.GetBranches.outputs.Result }}
+      TemplateUrl: ${{ steps.DetermineTemplateUrl.outputs.TemplateUrl }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read settings
+        id: ReadSettings
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
+        with:
+          shell: powershell
+          get: templateUrl
+
+      - name: Get Workflow Multi-Run Branches
+        id: GetBranches
+        uses: microsoft/AL-Go/Actions/GetWorkflowMultiRunBranches@41a2375645046812eb93fd5a67b5e0dd4a4438a1
+        with:
+          shell: powershell
+          includeBranches: ${{ github.event.inputs.includeBranches }}
+
+      - name: Determine Template URL
+        id: DetermineTemplateUrl
+        env:
+          TemplateUrlAsInput: '${{ github.event.inputs.templateUrl }}'
+        run: |
+            $templateUrl = $env:templateUrl # Available from ReadSettings step
+            if ($ENV:TemplateUrlAsInput) {
+              # Use the input value if it is provided
+              $templateUrl = $ENV:TemplateUrlAsInput
+            }
+            Write-Host "Using template URL: $templateUrl"
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "TemplateUrl=$templateUrl"
+
   UpdateALGoSystemFiles:
-    name: 'Update AL-Go System Files'
-    needs: [ ]
+    name: "[${{ matrix.branch }}] Update AL-Go System Files"
+    needs: [ Initialize ]
     runs-on: [ windows-latest ]
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}
+      fail-fast: false
+
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
-          get: templateUrl
+          get: commitOptions
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
-      - name: Override templateUrl
-        env:
-          templateUrl: ${{ github.event.inputs.templateUrl }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $templateUrl = $ENV:templateUrl
-          if ($templateUrl) {
-            Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
-          }
-
-      - name: Calculate Input
+      - name: Calculate Commit Options
         env:
           directCommit: '${{ github.event.inputs.directCommit }}'
-          downloadLatest: ${{ github.event.inputs.downloadLatest }}
-          eventName: ${{ github.event_name }}
+          downloadLatest: '${{ github.event.inputs.downloadLatest }}'
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $directCommit = $ENV:directCommit
-          $downloadLatest = $ENV:downloadLatest
-          Write-Host $ENV:eventName
-          if ($ENV:eventName -eq 'schedule') {
-            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit and DownloadLatest to true"
-            $directCommit = 'true'
-            $downloadLatest = 'true'
+          if('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            Write-Host "Using inputs from workflow_dispatch event"
+            $directCommit = $env:directCommit
+            $downloadLatest = $env:downloadLatest
+          }
+          else {
+            Write-Host "Using inputs from commitOptions setting"
+            $commitOptions = $env:commitOptions | ConvertFrom-Json # Available from ReadSettings step
+            $directCommit=$(-not $commitOptions.createPullRequest)
+            $downloadLatest=$true
           }
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "directCommit=$directCommit"
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           downloadLatest: ${{ env.downloadLatest }}
           update: 'Y'
-          templateUrl: ${{ env.templateUrl }}
+          templateUrl: ${{ needs.Initialize.outputs.TemplateUrl }}
           directCommit: ${{ env.directCommit }}
+          updateBranch: ${{ matrix.branch }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -99,7 +99,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSettings@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -118,7 +118,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/ReadSecrets@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,14 +136,14 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cache Business Central Artifacts
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: .artifactcache
           key: ${{ env.artifactCacheKey }}
@@ -151,7 +151,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -162,7 +162,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/RunPipeline@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -180,7 +180,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
-        uses: microsoft/AL-Go/Actions/Sign@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/Sign@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -197,7 +197,7 @@ jobs:
           suffix: ${{ inputs.artifactsNameSuffix }}
 
       - name: Publish artifacts - apps
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/Apps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
@@ -206,7 +206,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - dependencies
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: inputs.artifactsRetentionDays >= 0 && env.generateDependencyArtifact == 'True' && (hashFiles(format('{0}/.buildartifacts/Dependencies/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
@@ -215,7 +215,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - test apps
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: inputs.artifactsRetentionDays >= 0 && (hashFiles(format('{0}/.buildartifacts/TestApps/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
@@ -224,7 +224,7 @@ jobs:
           retention-days: ${{ inputs.artifactsRetentionDays }}
 
       - name: Publish artifacts - build output
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
@@ -232,7 +232,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
@@ -240,7 +240,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - test results
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
@@ -248,7 +248,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
@@ -256,7 +256,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test results
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResults.xml',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultsArtifactsName }}
@@ -264,7 +264,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish artifacts - page scripting test result details
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: (success() || failure()) && (hashFiles(format('{0}/.buildartifacts/PageScriptingTestResultDetails/*',inputs.project)) != '')
         with:
           name: ${{ steps.calculateArtifactsNames.outputs.PageScriptingTestResultDetailsArtifactsName }}
@@ -274,14 +274,14 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@98de5bf31c06a3bff621c640bdfbe7853f9f54c9
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@41a2375645046812eb93fd5a67b5e0dd4a4438a1
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Deprecations

- `alwaysBuildAllProjects` will be removed after October 1st 2025. Please set the `onPull_Request` property of the `incrementalBuilds` setting to false to force full builds in Pull Requests.
- `<workflow>Schedule` will be removed after October 1st 2025. The old setting, where the setting key was a combination of the workflow name and `Schedule` (dynamic setting key name) is deprecated. Instead you need to use a setting called [workflowSchedule](https://aka.ms/algosettings#workflowSchedule) and either use [Conditional Settings](https://aka.ms/algosettings#conditional-settings) or place the setting in a workflow specific settings file.

### Issues

- Issue 1433 Publish to Environment - DependencyInstallMode not found
- Issue 1440 Create Release fails due to recent changes to the AL-Go
- Issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
- Issue 1268 Do not throw an un-understandable error during nuGet download
- Performance test sample code in 25.4 contains objects with ID 149201 and 149202, which are not renumbered
- Issue 798 Publish To Environment breaks CI/CD pipelines
- Issue 1182 Runs-on setting type is ambiguous - string or array

### New Workflow specific settings

- `workflowSchedule` - can be structure with a property named `cron`, which must be a valid crontab, defining the CRON schedule for when the specified workflow should run. Default is no scheduled runs, only manual triggers. Build your crontab string here: [https://crontab.guru](https://crontab.guru). You need to run the Update AL-Go System Files workflow for the schedule to take effect.<br/>**Note:** If you configure a WorkflowSchedule for the CI/CD workflow, AL-Go will stop triggering CICDs on push unless you have also added CICDPushBranches to your settings.<br/>**Note also:** If you define a schedule for Update AL-Go System Files, it uses direct Commit instead of creating a PR.
- `workflowConcurrency` - is used to control concurrency of workflows. Like with the `workflowSchedule` setting, this setting should be applied in workflow specific settings files or conditional settings. By default, all workflows allows for concurrency, except for the Create Release workflow. If you are using incremental builds in CI/CD it is also recommented to set WorkflowConcurrency to:<br/>`[ "group: ${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress: true" ]`<br />in order to cancel prior incremental builds on the same branch.<br />Read more about workflow concurrency [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs).

### New Repository Settings

- `deployTo<environment>` now has two additional properties:
  - `includeTestAppsInSandboxEnvironment`, which deploys test apps and their dependencies to the specified sandbox environment if set to `true`. Deployment will fail if used on a Prod environment or if the test app has a dependency on Tests-TestLibraries. Default value is `false`.
  - `excludeAppIds`, which is an array of app ids which will be excluded from deployment. Default value is `[]`
- `incrementalBuilds` - is a structure defining how you want AL-Go to handle incremental builds. When using incremental builds for a build, AL-Go will look for the latest successful build, newer than the defined `retentionDays` and only rebuild projects or apps (based on `mode`) which needs to be rebuilt. Properties in the structure includes:
  - `onPush` - set this property to **true** in order to enable incremental builds in CI/CD triggered by a merge/push event. Default is **false**.
  - `onPull_Request` - set this property to **false** in order to disable incremental builds in Pull Request workflows. Default is **true**.
  - `onSchedule` - set this property to **true** in order to enable incremental builds in CI/CD when running on a schedule. Default is **false**.
  - `retentionDays` - number of days a successful build is good (and can be used for incremental builds). Default is **30**.
  - `mode` - defines the mode for incremental builds. Currently, two values are supported. Use **modifiedProjects** when you want to rebuild all apps in modified projects and depending projects or **modifiedApps** if you only want to rebuild modified apps and depending apps.

> [!NOTE]
> The projects mentioned here are AL-Go projects in a multi-project repository. A repository can contain multiple projects and a project can contain multiple apps.

### Run "Update AL-Go System Files" on multiple branches

_Update AL-Go System Files_ has a new input to specify a list of branches to be updated in a single workflow run.
When running the workflow on a schedule, you can now also specify `includeBranches` in `workflowSchedule` setting, which allows you to update the specified branches. Read more at https://aka.ms/algosettings#workflowSchedule.

> [!NOTE]
> When running "Update AL-Go System Files" on multiple branches, the template repository URL will be determined based on the branch the workflow runs on and it will be used for all of the specified branches.

### Support for incremental builds

AL-Go for GitHub now supports incremental builds, which means that unchanged projects or apps will be reused from the previous good build. Read [this](https://aka.ms/algosettings#incrementalBuilds) to learn more.

> [!NOTE]
> When using incremental builds it is recommended to also set `workflowConcurrency` as defined [here](https://aka.ms/algosettings#workflowConcurrency).

### Support for GitHub App authentication

AL-Go for GitHub now supports using a GitHub App specification as the GhTokenWorkflow secret for a more secure way of allowing repositories to run Update AL-Go System Files and other workflows which are creating commits and pull requests. See [this description](https://github.com/microsoft/AL-Go/blob/main/Scenarios/GhTokenWorkflow.md) to learn how to use GitHub App authentication.

### Support for embedded secrets in installApps and installTestApps settings

If your installApps or installTestApps are secure URL, containing a secret token, you can now use a GitHub secret specification as part of or as the full URL of apps to install. An example could be:

`"installApps": [ "https://www.dropbox.com/${{SECRETNAME}}&dl=1" ]`

Which would hide the secret part of your URL instead of exposing it in clear text.
